### PR TITLE
feat: support remote streamable-http transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# --- Endpoint protection (required) ---------------------------------------
+# Static bearer token clients must send: "Authorization: Bearer <token>".
+# Generate one with:  openssl rand -hex 32
+MCP_BEARER_TOKEN=change-me-please
+
+# --- Reverse proxy ----------------------------------------------------------
+# Set your public domain in the Caddyfile (phpipam.domaine.com -> your value).
+
+# --- phpIPAM credentials ----------------------------------------------------
+# Option A (shared): set these and all clients use the same phpIPAM app.
+# Option B (per-client): leave these EMPTY and have each client send
+#   X-phpIPAM-URL / X-phpIPAM-App-Id / X-phpIPAM-App-Code headers.
+PHPIPAM_URL=
+PHPIPAM_APP_ID=
+PHPIPAM_APP_CODE=
+PHPIPAM_VERIFY_SSL=true

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,8 @@
+# Replace with your real domain. Caddy will fetch a TLS cert automatically.
+phpipam.domaine.com {
+	# Forward everything (the MCP endpoint lives at /mcp, health at /health)
+	reverse_proxy phpipam-mcp:8000 {
+		# Keep streaming responses (SSE) flowing without buffering.
+		flush_interval -1
+	}
+}

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,205 @@
+# Déploiement du serveur MCP phpIPAM en mode distant (HTTP)
+
+Ce guide explique comment passer le serveur du mode `stdio` (installation locale
+sur le poste utilisateur) à un mode **distant** exposé sur une URL du type
+`https://phpipam.domaine.com/mcp`, accessible par n'importe quel client MCP
+compatible HTTP streamable.
+
+## Ce qui change
+
+Le serveur supporte désormais deux transports, choisis par la variable
+`MCP_TRANSPORT` :
+
+| Mode | `MCP_TRANSPORT` | Usage |
+|------|-----------------|-------|
+| Local (historique) | `stdio` (défaut) | Lancé par le client MCP sur la machine |
+| Distant | `streamable-http` | Service HTTP exposé sur `/mcp` derrière TLS |
+
+En mode distant :
+
+- l'endpoint MCP est servi sur le chemin `MCP_PATH` (défaut `/mcp`) ;
+- un **bearer token statique** (`MCP_BEARER_TOKEN`) protège l'accès ;
+- les identifiants phpIPAM sont fournis **par client** via des en-têtes HTTP
+  (`X-phpIPAM-*`), avec repli possible sur des variables d'environnement
+  partagées côté serveur ;
+- un endpoint `/health` non authentifié est disponible pour les sondes.
+
+## Fichiers fournis
+
+| Fichier | Rôle |
+|---------|------|
+| `src/phpipam_mcp_server/server.py` | Serveur adapté (remplace l'existant) |
+| `pyproject.toml` | Ajoute `uvicorn`, passe à Python 3.10+, v0.3.0 |
+| `Dockerfile` | Image du serveur en mode HTTP |
+| `docker-compose.yml` | Serveur + reverse proxy Caddy (TLS auto) |
+| `Caddyfile` | Configuration du domaine public |
+| `.env.example` | Modèle de variables d'environnement |
+
+## Configuration (variables d'environnement)
+
+| Variable | Défaut | Description |
+|----------|--------|-------------|
+| `MCP_TRANSPORT` | `stdio` | Mettre `streamable-http` pour le mode distant |
+| `MCP_HOST` | `0.0.0.0` | Adresse d'écoute (HTTP) |
+| `MCP_PORT` | `8000` | Port d'écoute (HTTP) |
+| `MCP_PATH` | `/mcp` | Chemin de l'endpoint MCP |
+| `MCP_BEARER_TOKEN` | — | Token requis dans `Authorization: Bearer <token>` |
+| `PHPIPAM_URL` | — | URL phpIPAM partagée (repli) |
+| `PHPIPAM_APP_ID` | — | App ID phpIPAM partagé (repli) |
+| `PHPIPAM_APP_CODE` | — | App Code phpIPAM partagé (repli) |
+| `PHPIPAM_VERIFY_SSL` | `true` | Vérification TLS vers phpIPAM |
+
+### En-têtes par client (mode « par client »)
+
+Chaque client peut fournir ses propres identifiants phpIPAM :
+
+```
+Authorization: Bearer <MCP_BEARER_TOKEN>
+X-phpIPAM-URL: https://ipam.example.com/
+X-phpIPAM-App-Id: mon_app_id
+X-phpIPAM-App-Code: mon_app_code_token
+X-phpIPAM-Verify-Ssl: true
+```
+
+Si un en-tête `X-phpIPAM-*` est absent, le serveur utilise la variable
+d'environnement correspondante. Vous pouvez donc laisser les variables
+`PHPIPAM_*` vides pour **imposer** des identifiants par client.
+
+## Déploiement avec Docker + Caddy (recommandé)
+
+1. Placez les fichiers fournis à la racine du dépôt (en remplaçant
+   `src/phpipam_mcp_server/server.py` et `pyproject.toml`).
+2. Créez le fichier `.env` :
+
+   ```bash
+   cp .env.example .env
+   # Générez un token solide :
+   echo "MCP_BEARER_TOKEN=$(openssl rand -hex 32)" >> .env
+   ```
+
+3. Renseignez votre domaine réel dans `Caddyfile` (remplacez
+   `phpipam.domaine.com`). Les ports 80 et 443 doivent être accessibles depuis
+   Internet pour l'émission du certificat Let's Encrypt.
+4. Démarrez :
+
+   ```bash
+   docker compose up -d --build
+   ```
+
+5. Vérifiez la santé :
+
+   ```bash
+   curl https://phpipam.domaine.com/health
+   # -> {"status":"ok"}
+   ```
+
+L'endpoint MCP est alors disponible sur `https://phpipam.domaine.com/mcp`.
+
+## Alternative : reverse proxy Nginx
+
+Si vous gérez déjà Nginx, exposez le conteneur (ou le service systemd) sur
+`127.0.0.1:8000` et utilisez :
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name phpipam.domaine.com;
+
+    ssl_certificate     /etc/letsencrypt/live/phpipam.domaine.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/phpipam.domaine.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Important pour le streaming (SSE) du transport MCP
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
+    }
+}
+```
+
+> Le serveur ne réécrit pas les en-têtes `Authorization` / `X-phpIPAM-*` :
+> assurez-vous que le proxy les transmet bien (Nginx le fait par défaut ; ne pas
+> ajouter de `proxy_set_header Authorization "";`).
+
+## Alternative : service systemd (sans Docker)
+
+```ini
+# /etc/systemd/system/phpipam-mcp.service
+[Unit]
+Description=phpIPAM MCP Server (HTTP)
+After=network-online.target
+
+[Service]
+User=phpipam-mcp
+Environment=MCP_TRANSPORT=streamable-http
+Environment=MCP_HOST=127.0.0.1
+Environment=MCP_PORT=8000
+EnvironmentFile=/etc/phpipam-mcp/env
+ExecStart=/opt/phpipam-mcp/venv/bin/phpipam-mcp-server
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+python3 -m venv /opt/phpipam-mcp/venv
+/opt/phpipam-mcp/venv/bin/pip install /chemin/vers/le/depot
+systemctl enable --now phpipam-mcp
+```
+
+## Configuration côté client MCP
+
+Pour un client supportant les serveurs MCP HTTP distants :
+
+```json
+{
+  "mcpServers": {
+    "phpipam": {
+      "type": "http",
+      "url": "https://phpipam.domaine.com/mcp",
+      "headers": {
+        "Authorization": "Bearer <MCP_BEARER_TOKEN>",
+        "X-phpIPAM-URL": "https://ipam.example.com/",
+        "X-phpIPAM-App-Id": "mon_app_id",
+        "X-phpIPAM-App-Code": "mon_app_code_token"
+      }
+    }
+  }
+}
+```
+
+> Si vous utilisez des identifiants phpIPAM partagés côté serveur, omettez les
+> en-têtes `X-phpIPAM-*` et ne gardez que `Authorization`.
+
+## Test rapide en ligne de commande
+
+```bash
+# Doit renvoyer 401 sans token
+curl -i https://phpipam.domaine.com/mcp
+
+# Avec token : initialise une session MCP (réponse JSON-RPC)
+curl -s https://phpipam.domaine.com/mcp \
+  -H "Authorization: Bearer <MCP_BEARER_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"1"}}}'
+```
+
+## Notes de sécurité
+
+- Le bearer token transite en clair : ne l'exposez **que** derrière HTTPS (le
+  reverse proxy s'en charge). Ne publiez jamais l'endpoint en HTTP nu.
+- Faites tourner (rotation) le `MCP_BEARER_TOKEN` régulièrement.
+- Le serveur expose des opérations d'écriture/suppression phpIPAM
+  (`create_subnet`, `delete_subnet`, `delete_ip_address`, …). Limitez les
+  permissions de l'application phpIPAM au strict nécessaire.
+- En mode stateless, des messages `ClosedResourceError` peuvent apparaître dans
+  les logs lors du teardown des sessions éphémères : c'est sans conséquence sur
+  les réponses.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# phpIPAM MCP Server - remote (streamable-http) image
+FROM python:3.12-slim
+
+# Avoid interactive prompts, write .pyc straight to stdout
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+# Install the package + ASGI server. Copy metadata first for better caching.
+COPY pyproject.toml README.md ./
+COPY src ./src
+RUN pip install --no-cache-dir . "uvicorn[standard]>=0.30"
+
+# Remote-mode defaults (override at runtime / via compose)
+ENV MCP_TRANSPORT=streamable-http \
+    MCP_HOST=0.0.0.0 \
+    MCP_PORT=8000 \
+    MCP_PATH=/mcp
+
+EXPOSE 8000
+
+# Run as an unprivileged user
+RUN useradd --uid 10001 --no-create-home --shell /usr/sbin/nologin appuser
+USER 10001
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/health',timeout=3).status==200 else 1)" || exit 1
+
+CMD ["phpipam-mcp-server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+services:
+  phpipam-mcp:
+    build: .
+    image: phpipam-mcp-server:latest
+    container_name: phpipam-mcp
+    environment:
+      MCP_TRANSPORT: streamable-http
+      MCP_HOST: "0.0.0.0"
+      MCP_PORT: "8000"
+      MCP_PATH: /mcp
+      # Static bearer token protecting the endpoint (required). See .env
+      MCP_BEARER_TOKEN: ${MCP_BEARER_TOKEN:?set MCP_BEARER_TOKEN in .env}
+      # Optional server-wide phpIPAM fallback creds. Leave empty to force
+      # per-client credentials passed through HTTP headers.
+      PHPIPAM_URL: ${PHPIPAM_URL:-}
+      PHPIPAM_APP_ID: ${PHPIPAM_APP_ID:-}
+      PHPIPAM_APP_CODE: ${PHPIPAM_APP_CODE:-}
+      PHPIPAM_VERIFY_SSL: ${PHPIPAM_VERIFY_SSL:-true}
+    expose:
+      - "8000"
+    restart: unless-stopped
+
+  # TLS termination + public domain. Caddy obtains a Let's Encrypt cert
+  # automatically for the configured domain (ports 80/443 must be reachable).
+  caddy:
+    image: caddy:2
+    container_name: phpipam-mcp-caddy
+    depends_on:
+      - phpipam-mcp
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    restart: unless-stopped
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,23 +4,22 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "phpipam-mcp-server"
-version = "0.2.1"
+version = "0.3.0"
 description = "MCP server for phpIPAM IP address management and network infrastructure"
 authors = [{name = "Rory McMahon", email = "rory.mcmahon@vocus.com.au"}]
 license = {text = "MIT"}
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "mcp==1.14.1",
     "requests==2.32.5",
+    "uvicorn[standard]>=0.30",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -57,14 +56,14 @@ where = ["src"]
 
 [tool.black]
 line-length = 88
-target-version = ['py38']
+target-version = ['py310']
 
 [tool.isort]
 profile = "black"
 line_length = 88
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/src/phpipam_mcp_server/server.py
+++ b/src/phpipam_mcp_server/server.py
@@ -1,31 +1,107 @@
 #!/usr/bin/env python3
-"""phpIPAM MCP Server - Provides phpIPAM API access through MCP protocol."""
+"""phpIPAM MCP Server - Provides phpIPAM API access through MCP protocol.
 
+Supports two transports:
+
+* ``stdio``           : classic local mode (default, backwards compatible).
+* ``streamable-http`` : remote mode, exposes the server on an HTTP endpoint
+                        (e.g. https://phpipam.domaine.com/mcp) behind a reverse
+                        proxy that terminates TLS.
+
+Configuration (environment variables)
+--------------------------------------
+Transport / network:
+    MCP_TRANSPORT     "stdio" (default) or "streamable-http"
+    MCP_HOST          bind address in HTTP mode (default "0.0.0.0")
+    MCP_PORT          bind port in HTTP mode (default "8000")
+    MCP_PATH          HTTP path for the MCP endpoint (default "/mcp")
+    MCP_BEARER_TOKEN  if set, clients must send "Authorization: Bearer <token>"
+
+phpIPAM credentials (server-wide fallback; can be overridden per client
+through HTTP headers in remote mode):
+    PHPIPAM_URL, PHPIPAM_APP_ID, PHPIPAM_APP_CODE
+    PHPIPAM_VERIFY_SSL  "true" (default) / "false"
+
+Per-client phpIPAM credentials (remote mode, sent as HTTP headers):
+    X-phpIPAM-URL, X-phpIPAM-App-Id, X-phpIPAM-App-Code, X-phpIPAM-Verify-Ssl
+"""
+
+import contextvars
+import hmac
 import os
+
 import requests
 from mcp.server.fastmcp import FastMCP
 
-# Create MCP server
-mcp = FastMCP("phpIPAM Server")
+# ---------------------------------------------------------------------------
+# Remote (HTTP) request context
+# ---------------------------------------------------------------------------
+# In HTTP mode an ASGI middleware stores the incoming request headers here so
+# that the tool functions can resolve per-client phpIPAM credentials without
+# having to thread a Context object through every tool.
+_request_headers: contextvars.ContextVar[dict] = contextvars.ContextVar(
+    "phpipam_request_headers", default={}
+)
+
+
+def _env_truthy(value: str | None, default: bool = True) -> bool:
+    """Interpret an environment/header string as a boolean."""
+    if value is None:
+        return default
+    return value.strip().lower() not in ("0", "false", "no", "off", "")
+
+
+# Create MCP server. Host/port/path only matter for the HTTP transport.
+mcp = FastMCP(
+    "phpIPAM Server",
+    host=os.getenv("MCP_HOST", "0.0.0.0"),
+    port=int(os.getenv("MCP_PORT", "8000")),
+    streamable_http_path=os.getenv("MCP_PATH", "/mcp"),
+    # Stateless + JSON responses keep the remote endpoint simple and scalable
+    # behind a reverse proxy / load balancer.
+    stateless_http=True,
+    json_response=True,
+)
+
 
 def get_phpipam_config():
-    """Get phpIPAM configuration from environment variables"""
-    base_url = os.getenv('PHPIPAM_URL')
-    app_id = os.getenv('PHPIPAM_APP_ID')
-    token = os.getenv('PHPIPAM_APP_CODE')
+    """Resolve phpIPAM configuration.
+
+    Resolution order for each value:
+      1. Per-client HTTP header (remote mode), e.g. ``X-phpIPAM-URL``.
+      2. Server-wide environment variable, e.g. ``PHPIPAM_URL``.
+    """
+    headers = _request_headers.get()
+
+    base_url = headers.get("x-phpipam-url") or os.getenv("PHPIPAM_URL")
+    app_id = headers.get("x-phpipam-app-id") or os.getenv("PHPIPAM_APP_ID")
+    token = headers.get("x-phpipam-app-code") or os.getenv("PHPIPAM_APP_CODE")
+
+    verify_raw = headers.get("x-phpipam-verify-ssl")
+    if verify_raw is None:
+        verify_raw = os.getenv("PHPIPAM_VERIFY_SSL")
+    verify_ssl = _env_truthy(verify_raw, default=True)
 
     if not base_url:
-        raise ValueError("PHPIPAM_URL environment variable is required")
+        raise ValueError(
+            "phpIPAM URL is required (PHPIPAM_URL env var or X-phpIPAM-URL header)"
+        )
     if not app_id:
-        raise ValueError("PHPIPAM_APP_ID environment variable is required")
+        raise ValueError(
+            "phpIPAM App ID is required "
+            "(PHPIPAM_APP_ID env var or X-phpIPAM-App-Id header)"
+        )
     if not token:
-        raise ValueError("PHPIPAM_APP_CODE environment variable is required")
+        raise ValueError(
+            "phpIPAM App Code is required "
+            "(PHPIPAM_APP_CODE env var or X-phpIPAM-App-Code header)"
+        )
 
     return {
         'base_url': base_url.rstrip('/'),
         'app_id': app_id,
         'token': token,
-        'verify_ssl': True
+        'verify_ssl': verify_ssl
     }
 
 def filter_fields(data, include_fields=None, exclude_fields=None):
@@ -329,6 +405,49 @@ def search_addresses(ip_or_hostname: str, limit: int = 10) -> str:
             return f"No addresses found matching '{ip_or_hostname}'. " + \
                    "Try searching with a complete IP address or exact hostname."
         return _handle_error(e, f"searching for '{ip_or_hostname}'")
+
+@mcp.tool()
+def search_hostname(hostname: str, limit: int = 10) -> str:
+    """Search for IP addresses by exact or partial hostname in phpIPAM.
+
+    CONTEXT OPTIMIZATION: Limited to 10 results by default.
+
+    Args:
+        hostname: Hostname to search for
+        limit: Maximum number of results to return (default: 10, max: 50)
+    """
+    try:
+        if '*' in hostname:
+            import fnmatch
+            result = make_request("addresses/")
+            if not result.get('success'):
+                return f"API Error: {result.get('message', 'Failed to fetch addresses')}"
+
+            all_addresses = result.get('data', [])
+            addresses = [
+                addr for addr in all_addresses
+                if addr.get('hostname') and fnmatch.fnmatch(addr.get('hostname', '').lower(), hostname.lower())
+            ]
+        else:
+            result = make_request(f"addresses/search_hostname/{hostname}/")
+            if not result.get('success'):
+                return f"API Error: {result.get('message', 'No results found')}"
+            addresses = result.get('data', [])
+
+        if not addresses:
+            return f"No addresses found matching hostname '{hostname}'"
+
+        # Apply limit and field filtering
+        addresses, truncated = apply_result_limit(addresses, limit, 50)
+        default_fields = ['id', 'subnetId', 'ip', 'hostname', 'description']
+        addresses = apply_field_filtering(addresses, "", default_fields)
+
+        return format_address_output(addresses, hostname, limit, truncated)
+
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        if "404" in str(e):
+            return f"No addresses found matching hostname '{hostname}'."
+        return _handle_error(e, f"searching for hostname '{hostname}'")
 
 @mcp.tool()
 def get_subnet_details(subnet_id: str, include_addresses: bool = False,
@@ -737,9 +856,88 @@ def delete_subnet(subnet_id: str) -> str:
     except Exception as e:  # pylint: disable=broad-exception-caught
         return _handle_error(e, f"deleting subnet {subnet_id}")
 
+
+# ---------------------------------------------------------------------------
+# Health check (useful for reverse proxies / container orchestration)
+# ---------------------------------------------------------------------------
+@mcp.custom_route("/health", methods=["GET"])
+async def health_check(_request):  # pragma: no cover - trivial
+    """Liveness probe; does not touch phpIPAM."""
+    from starlette.responses import JSONResponse
+    return JSONResponse({"status": "ok"})
+
+
+# ---------------------------------------------------------------------------
+# Remote-mode middleware: bearer auth + per-client header capture
+# ---------------------------------------------------------------------------
+class RemoteContextMiddleware:
+    """Pure-ASGI middleware (runs in the same task as the endpoint, so the
+    contextvar set here is visible to the tool functions).
+
+    Responsibilities:
+      * Enforce a static bearer token when MCP_BEARER_TOKEN is set.
+      * Capture incoming HTTP headers into a contextvar for per-client creds.
+    """
+
+    def __init__(self, app):
+        self.app = app
+        self.expected_token = os.getenv("MCP_BEARER_TOKEN")
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = {
+            k.decode("latin-1").lower(): v.decode("latin-1")
+            for k, v in scope.get("headers", [])
+        }
+
+        # Allow unauthenticated health checks.
+        path = scope.get("path", "")
+        if self.expected_token and not path.rstrip("/").endswith("/health"):
+            provided = headers.get("authorization", "")
+            prefix = "Bearer "
+            ok = provided.startswith(prefix) and hmac.compare_digest(
+                provided[len(prefix):], self.expected_token
+            )
+            if not ok:
+                from starlette.responses import JSONResponse
+                response = JSONResponse(
+                    {"error": "unauthorized"},
+                    status_code=401,
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+                await response(scope, receive, send)
+                return
+
+        token = _request_headers.set(headers)
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            _request_headers.reset(token)
+
+
+def build_http_app():
+    """Build the Starlette ASGI app for remote (streamable-http) mode."""
+    app = mcp.streamable_http_app()
+    return RemoteContextMiddleware(app)
+
+
 def main():
     """Main entry point for the MCP server."""
-    mcp.run()
+    transport = os.getenv("MCP_TRANSPORT", "stdio").lower()
+
+    if transport in ("streamable-http", "http", "streamable_http"):
+        import uvicorn
+        uvicorn.run(
+            build_http_app(),
+            host=mcp.settings.host,
+            port=mcp.settings.port,
+            log_level=mcp.settings.log_level.lower(),
+        )
+    else:
+        mcp.run()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- server.py: add streamable-http transport (MCP_TRANSPORT=streamable-http), bearer-token auth middleware (MCP_BEARER_TOKEN) and per-client phpIPAM credentials via X-phpIPAM-* HTTP headers (env-var fallback). Adds /health. stdio mode remains the default (backward compatible).
- pyproject.toml: add uvicorn dependency, require Python 3.10+, bump to 0.3.0.
- Dockerfile, docker-compose.yml (with Caddy TLS), Caddyfile, .env.example.
- DEPLOYMENT.md: remote deployment + client config guide.